### PR TITLE
feat: support Gemini 3.5 Flash

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,11 +53,11 @@ ScreenScribe allows you to choose between the following Gemini models to optimiz
 
 | Model | Description |
 |-------|-------------|
-| **Gemini 3 Flash** | Best balance of speed, cost, and accuracy |
-| **Gemini 3 Pro** | Most capable model for complex content |
-| **Gemini 2.5 Flash-Lite** | Fastest and most cost-effective option |
+| **Gemini 3.5 Flash** | Best balance of speed, cost, and accuracy |
+| **Gemini 3.1 Pro** | Most capable model for complex content |
+| **Gemini 3.1 Flash-Lite** | Fastest and most cost-effective option |
 
-> Note: All models are available on the free tier that includes a generous [usage limit](https://ai.google.dev/gemini-api/docs/rate-limits) that should be more than sufficient for personal use.
+> Note: Availability and quotas can change; see Google's current [usage limits](https://ai.google.dev/gemini-api/docs/rate-limits) for details.
 
 ## Installation
 

--- a/ScreenScribe/Sources/Config.swift
+++ b/ScreenScribe/Sources/Config.swift
@@ -36,7 +36,7 @@ struct GeminiModel: Identifiable {
 
 /// Central configuration access point for the application
 enum Config {
-    static let defaultGeminiModelID = "gemini-3-flash-preview"
+    static let defaultGeminiModelID = "gemini-3.5-flash"
 
     /// The Gemini API key loaded from Keychain or Secrets.plist
     @MainActor
@@ -49,13 +49,15 @@ enum Config {
     
     /// Available Gemini models to choose from
     static let availableGeminiModels: [GeminiModel] = [
-        .init(id: "gemini-3-flash-preview", label: "Gemini 3 Flash", note: "Best balance"),
+        .init(id: "gemini-3.5-flash", label: "Gemini 3.5 Flash", note: "Best balance"),
         .init(id: "gemini-3.1-pro-preview", label: "Gemini 3.1 Pro", note: "Most capable"),
         .init(id: "gemini-3.1-flash-lite-preview", label: "Gemini 3.1 Flash-Lite", note: "Fastest"),
     ]
 
     static func migratedGeminiModelID(_ modelID: String) -> String {
         switch modelID {
+        case "gemini-3-flash-preview":
+            return "gemini-3.5-flash"
         case "gemini-3-pro-preview":
             return "gemini-3.1-pro-preview"
         case "gemini-2.5-flash-lite":

--- a/Tests/GeminiModelCatalogTests.swift
+++ b/Tests/GeminiModelCatalogTests.swift
@@ -12,15 +12,20 @@ struct GeminiModelCatalogTests {
     static func main() {
         let modelIDs = Config.availableGeminiModels.map(\.id)
 
-        expect(modelIDs.contains("gemini-3-flash-preview"), "Gemini 3 Flash should remain available")
+        expect(modelIDs.contains("gemini-3.5-flash"), "Gemini 3.5 Flash should be available")
         expect(modelIDs.contains("gemini-3.1-pro-preview"), "Gemini 3.1 Pro Preview should be available")
         expect(modelIDs.contains("gemini-3.1-flash-lite-preview"), "Gemini 3.1 Flash-Lite Preview should be available")
+        expect(!modelIDs.contains("gemini-3-flash-preview"), "Gemini 3 Flash Preview should be removed from the catalog")
         expect(!modelIDs.contains("gemini-3-pro-preview"), "Gemini 3 Pro Preview should be removed from the catalog")
         expect(!modelIDs.contains("gemini-2.5-flash-lite"), "Gemini 2.5 Flash-Lite should be removed from the catalog")
 
         expect(
-            Config.defaultGeminiModelID == "gemini-3-flash-preview",
-            "The default Gemini model should remain Gemini 3 Flash"
+            Config.defaultGeminiModelID == "gemini-3.5-flash",
+            "The default Gemini model should be Gemini 3.5 Flash"
+        )
+        expect(
+            Config.migratedGeminiModelID("gemini-3-flash-preview") == "gemini-3.5-flash",
+            "Stored Gemini 3 Flash Preview selections should migrate to Gemini 3.5 Flash"
         )
         expect(
             Config.migratedGeminiModelID("gemini-3-pro-preview") == "gemini-3.1-pro-preview",
@@ -31,8 +36,12 @@ struct GeminiModelCatalogTests {
             "Stored Gemini 2.5 Flash-Lite selections should migrate to Gemini 3.1 Flash-Lite Preview"
         )
         expect(
-            Config.migratedGeminiModelID("gemini-3-flash-preview") == "gemini-3-flash-preview",
+            Config.migratedGeminiModelID("gemini-3.5-flash") == "gemini-3.5-flash",
             "Current supported selections should remain unchanged"
+        )
+        expect(
+            Config.persistedGeminiModelMigration(from: "gemini-3-flash-preview") == "gemini-3.5-flash",
+            "Only the deprecated Gemini 3 Flash Preview setting should be rewritten in storage"
         )
         expect(
             Config.persistedGeminiModelMigration(from: "gemini-3-pro-preview") == "gemini-3.1-pro-preview",
@@ -43,12 +52,16 @@ struct GeminiModelCatalogTests {
             "Only the deprecated Gemini 2.5 Flash-Lite setting should be rewritten in storage"
         )
         expect(
-            Config.persistedGeminiModelMigration(from: "gemini-3-flash-preview") == nil,
+            Config.persistedGeminiModelMigration(from: "gemini-3.5-flash") == nil,
             "Supported Gemini selections should not be rewritten in storage"
         )
         expect(
             Config.persistedGeminiModelMigration(from: "gemini-custom-experimental") == nil,
             "Unknown custom Gemini selections should not be overwritten during migration"
+        )
+        expect(
+            Config.requestGeminiModelID(from: "gemini-3-flash-preview") == "gemini-3.5-flash",
+            "Deprecated Gemini 3 Flash Preview requests should be upgraded automatically"
         )
         expect(
             Config.requestGeminiModelID(from: "gemini-3-pro-preview") == "gemini-3.1-pro-preview",
@@ -59,7 +72,7 @@ struct GeminiModelCatalogTests {
             "Custom Gemini selections should still be used for requests"
         )
         expect(
-            Config.requestGeminiModelID(from: nil) == "gemini-3-flash-preview",
+            Config.requestGeminiModelID(from: nil) == "gemini-3.5-flash",
             "Missing Gemini selections should still use the default request model"
         )
 


### PR DESCRIPTION
## Summary

- update the Gemini catalog default from Gemini 3 Flash Preview to Gemini 3.5 Flash
- migrate stored `gemini-3-flash-preview` selections to `gemini-3.5-flash`
- update README model documentation and catalog regression coverage

## Validation

- `scripts/run-standalone-tests.sh`
- `git diff --check HEAD~1 HEAD`
- `xcodebuild -project ScreenScribe.xcodeproj -scheme ScreenScribe -configuration Debug -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO ENABLE_DEBUG_DYLIB=NO build -quiet`\n- live Gemini smoke test during local verification confirmed `gemini-3.5-flash` accepts the existing GenerateContent image request path\n\n## Release Plan\n\nAfter this PR is merged and CI is green, dispatch the `Build and Release` workflow with version `2.1.1` to publish a signed DMG.