### PR TITLE
feat: support Gemini 3.6 Flash and 3.5 Flash-Lite

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,9 +53,9 @@ ScreenScribe allows you to choose between the following Gemini models to optimiz
 
 | Model | Description |
 |-------|-------------|
-| **Gemini 3.5 Flash** | Best balance of speed, cost, and accuracy |
+| **Gemini 3.6 Flash** | Best balance of speed, cost, and accuracy |
 | **Gemini 3.1 Pro** | Most capable model for complex content |
-| **Gemini 3.1 Flash-Lite** | Fastest and most cost-effective option |
+| **Gemini 3.5 Flash-Lite** | Fastest and most cost-effective option |
 
 > Note: Availability and quotas can change; see Google's current [usage limits](https://ai.google.dev/gemini-api/docs/rate-limits) for details.
 

--- a/ScreenScribe/Sources/Config.swift
+++ b/ScreenScribe/Sources/Config.swift
@@ -36,7 +36,7 @@ struct GeminiModel: Identifiable {
 
 /// Central configuration access point for the application
 enum Config {
-    static let defaultGeminiModelID = "gemini-3.5-flash"
+    static let defaultGeminiModelID = "gemini-3.6-flash"
 
     /// The Gemini API key loaded from Keychain or Secrets.plist
     @MainActor
@@ -49,19 +49,19 @@ enum Config {
     
     /// Available Gemini models to choose from
     static let availableGeminiModels: [GeminiModel] = [
-        .init(id: "gemini-3.5-flash", label: "Gemini 3.5 Flash", note: "Best balance"),
+        .init(id: "gemini-3.6-flash", label: "Gemini 3.6 Flash", note: "Best balance"),
         .init(id: "gemini-3.1-pro-preview", label: "Gemini 3.1 Pro", note: "Most capable"),
-        .init(id: "gemini-3.1-flash-lite-preview", label: "Gemini 3.1 Flash-Lite", note: "Fastest"),
+        .init(id: "gemini-3.5-flash-lite", label: "Gemini 3.5 Flash-Lite", note: "Fastest"),
     ]
 
     static func migratedGeminiModelID(_ modelID: String) -> String {
         switch modelID {
-        case "gemini-3-flash-preview":
-            return "gemini-3.5-flash"
+        case "gemini-3-flash-preview", "gemini-3.5-flash":
+            return "gemini-3.6-flash"
         case "gemini-3-pro-preview":
             return "gemini-3.1-pro-preview"
-        case "gemini-2.5-flash-lite":
-            return "gemini-3.1-flash-lite-preview"
+        case "gemini-2.5-flash-lite", "gemini-3.1-flash-lite", "gemini-3.1-flash-lite-preview":
+            return "gemini-3.5-flash-lite"
         default:
             return modelID
         }

--- a/ScreenScribe/Sources/Services/GeminiService.swift
+++ b/ScreenScribe/Sources/Services/GeminiService.swift
@@ -45,29 +45,19 @@ struct GeminiService {
         self.maxRetries = maxRetries
         self.initialDelay = initialDelay
     }
-    
+
     private func shouldRetry(statusCode: Int, error: Error?) -> Bool {
         // Implement retry logic here
         // For example:
         return statusCode >= 500 || error is URLError && (error as? URLError)?.code == .networkConnectionLost
     }
-    
-    /// Extract content from an image using a customizable prompt
-    /// - Parameters:
-    ///   - base64Image: The image encoded as base64 PNG
-    ///   - apiKey: The Gemini API key
-    ///   - promptContent: The system prompt to use for extraction
-    /// - Returns: The extracted content as a string
-    func extractContent(from base64Image: String, apiKey: String, promptContent: String) async throws -> String {
-        guard !apiKey.isEmpty else {
-            throw GeminiAPIError.apiKeyMissing
-        }
 
-        // Get the selected model from UserDefaults
-        let model = Config.requestGeminiModelID(
-            from: UserDefaults.standard.string(forKey: "geminiModel")
-        )
-
+    static func makeRequest(
+        base64Image: String,
+        apiKey: String,
+        promptContent: String,
+        model: String
+    ) throws -> URLRequest {
         let payload: [String: Any] = [
             "contents": [[
                 "parts": [
@@ -83,21 +73,42 @@ struct GeminiService {
                 ]
             ],
             "generationConfig": [
-                "temperature": 0,
-                "candidateCount": 1,
                 "maxOutputTokens": 2048
             ]
         ]
-        
-        // Build URL with the specified model
+
         guard let url = URL(string: "\(Config.geminiEndpoint(for: model))?key=\(apiKey)") else {
             throw GeminiAPIError.invalidResponse
         }
-        
+
         var request = URLRequest(url: url)
         request.httpMethod = "POST"
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
         request.httpBody = try JSONSerialization.data(withJSONObject: payload)
+        return request
+    }
+
+    /// Extract content from an image using a customizable prompt
+    /// - Parameters:
+    ///   - base64Image: The image encoded as base64 PNG
+    ///   - apiKey: The Gemini API key
+    ///   - promptContent: The system prompt to use for extraction
+    /// - Returns: The extracted content as a string
+    func extractContent(from base64Image: String, apiKey: String, promptContent: String) async throws -> String {
+        guard !apiKey.isEmpty else {
+            throw GeminiAPIError.apiKeyMissing
+        }
+
+        // Get the selected model from UserDefaults
+        let model = Config.requestGeminiModelID(
+            from: UserDefaults.standard.string(forKey: "geminiModel")
+        )
+        let request = try Self.makeRequest(
+            base64Image: base64Image,
+            apiKey: apiKey,
+            promptContent: promptContent,
+            model: model
+        )
         
         var retryCount = 0
         while retryCount <= maxRetries {

--- a/Tests/GeminiModelCatalogTests.swift
+++ b/Tests/GeminiModelCatalogTests.swift
@@ -12,47 +12,69 @@ struct GeminiModelCatalogTests {
     static func main() {
         let modelIDs = Config.availableGeminiModels.map(\.id)
 
-        expect(modelIDs.contains("gemini-3.5-flash"), "Gemini 3.5 Flash should be available")
+        expect(modelIDs.contains("gemini-3.6-flash"), "Gemini 3.6 Flash should be available")
         expect(modelIDs.contains("gemini-3.1-pro-preview"), "Gemini 3.1 Pro Preview should be available")
-        expect(modelIDs.contains("gemini-3.1-flash-lite-preview"), "Gemini 3.1 Flash-Lite Preview should be available")
+        expect(modelIDs.contains("gemini-3.5-flash-lite"), "Gemini 3.5 Flash-Lite should be available")
+        expect(!modelIDs.contains("gemini-3.5-flash"), "Gemini 3.5 Flash should be removed from the catalog")
+        expect(!modelIDs.contains("gemini-3.1-flash-lite-preview"), "Gemini 3.1 Flash-Lite Preview should be removed from the catalog")
         expect(!modelIDs.contains("gemini-3-flash-preview"), "Gemini 3 Flash Preview should be removed from the catalog")
         expect(!modelIDs.contains("gemini-3-pro-preview"), "Gemini 3 Pro Preview should be removed from the catalog")
         expect(!modelIDs.contains("gemini-2.5-flash-lite"), "Gemini 2.5 Flash-Lite should be removed from the catalog")
 
         expect(
-            Config.defaultGeminiModelID == "gemini-3.5-flash",
-            "The default Gemini model should be Gemini 3.5 Flash"
+            Config.defaultGeminiModelID == "gemini-3.6-flash",
+            "The default Gemini model should be Gemini 3.6 Flash"
         )
         expect(
-            Config.migratedGeminiModelID("gemini-3-flash-preview") == "gemini-3.5-flash",
-            "Stored Gemini 3 Flash Preview selections should migrate to Gemini 3.5 Flash"
+            Config.migratedGeminiModelID("gemini-3.5-flash") == "gemini-3.6-flash",
+            "Stored Gemini 3.5 Flash selections should migrate to Gemini 3.6 Flash"
+        )
+        expect(
+            Config.migratedGeminiModelID("gemini-3-flash-preview") == "gemini-3.6-flash",
+            "Stored Gemini 3 Flash Preview selections should migrate to Gemini 3.6 Flash"
         )
         expect(
             Config.migratedGeminiModelID("gemini-3-pro-preview") == "gemini-3.1-pro-preview",
             "Stored Gemini 3 Pro Preview selections should migrate to Gemini 3.1 Pro Preview"
         )
         expect(
-            Config.migratedGeminiModelID("gemini-2.5-flash-lite") == "gemini-3.1-flash-lite-preview",
-            "Stored Gemini 2.5 Flash-Lite selections should migrate to Gemini 3.1 Flash-Lite Preview"
+            Config.migratedGeminiModelID("gemini-3.1-flash-lite-preview") == "gemini-3.5-flash-lite",
+            "Stored Gemini 3.1 Flash-Lite selections should migrate to Gemini 3.5 Flash-Lite"
         )
         expect(
-            Config.migratedGeminiModelID("gemini-3.5-flash") == "gemini-3.5-flash",
+            Config.migratedGeminiModelID("gemini-3.1-flash-lite") == "gemini-3.5-flash-lite",
+            "Stored Gemini 3.1 Flash-Lite stable selections should migrate to Gemini 3.5 Flash-Lite"
+        )
+        expect(
+            Config.migratedGeminiModelID("gemini-2.5-flash-lite") == "gemini-3.5-flash-lite",
+            "Stored Gemini 2.5 Flash-Lite selections should migrate to Gemini 3.5 Flash-Lite"
+        )
+        expect(
+            Config.migratedGeminiModelID("gemini-3.6-flash") == "gemini-3.6-flash",
             "Current supported selections should remain unchanged"
         )
         expect(
-            Config.persistedGeminiModelMigration(from: "gemini-3-flash-preview") == "gemini-3.5-flash",
-            "Only the deprecated Gemini 3 Flash Preview setting should be rewritten in storage"
+            Config.persistedGeminiModelMigration(from: "gemini-3.5-flash") == "gemini-3.6-flash",
+            "The deprecated Gemini 3.5 Flash setting should be rewritten in storage"
+        )
+        expect(
+            Config.persistedGeminiModelMigration(from: "gemini-3-flash-preview") == "gemini-3.6-flash",
+            "The deprecated Gemini 3 Flash Preview setting should be rewritten in storage"
         )
         expect(
             Config.persistedGeminiModelMigration(from: "gemini-3-pro-preview") == "gemini-3.1-pro-preview",
-            "Only the deprecated Gemini 3 Pro Preview setting should be rewritten in storage"
+            "The deprecated Gemini 3 Pro Preview setting should be rewritten in storage"
         )
         expect(
-            Config.persistedGeminiModelMigration(from: "gemini-2.5-flash-lite") == "gemini-3.1-flash-lite-preview",
-            "Only the deprecated Gemini 2.5 Flash-Lite setting should be rewritten in storage"
+            Config.persistedGeminiModelMigration(from: "gemini-3.1-flash-lite-preview") == "gemini-3.5-flash-lite",
+            "The deprecated Gemini 3.1 Flash-Lite setting should be rewritten in storage"
         )
         expect(
-            Config.persistedGeminiModelMigration(from: "gemini-3.5-flash") == nil,
+            Config.persistedGeminiModelMigration(from: "gemini-2.5-flash-lite") == "gemini-3.5-flash-lite",
+            "The deprecated Gemini 2.5 Flash-Lite setting should be rewritten in storage"
+        )
+        expect(
+            Config.persistedGeminiModelMigration(from: "gemini-3.6-flash") == nil,
             "Supported Gemini selections should not be rewritten in storage"
         )
         expect(
@@ -60,7 +82,11 @@ struct GeminiModelCatalogTests {
             "Unknown custom Gemini selections should not be overwritten during migration"
         )
         expect(
-            Config.requestGeminiModelID(from: "gemini-3-flash-preview") == "gemini-3.5-flash",
+            Config.requestGeminiModelID(from: "gemini-3.5-flash") == "gemini-3.6-flash",
+            "Deprecated Gemini 3.5 Flash requests should be upgraded automatically"
+        )
+        expect(
+            Config.requestGeminiModelID(from: "gemini-3-flash-preview") == "gemini-3.6-flash",
             "Deprecated Gemini 3 Flash Preview requests should be upgraded automatically"
         )
         expect(
@@ -68,11 +94,15 @@ struct GeminiModelCatalogTests {
             "Deprecated Gemini 3 Pro Preview requests should be upgraded automatically"
         )
         expect(
+            Config.requestGeminiModelID(from: "gemini-3.1-flash-lite-preview") == "gemini-3.5-flash-lite",
+            "Deprecated Gemini 3.1 Flash-Lite requests should be upgraded automatically"
+        )
+        expect(
             Config.requestGeminiModelID(from: "gemini-custom-experimental") == "gemini-custom-experimental",
             "Custom Gemini selections should still be used for requests"
         )
         expect(
-            Config.requestGeminiModelID(from: nil) == "gemini-3.5-flash",
+            Config.requestGeminiModelID(from: nil) == "gemini-3.6-flash",
             "Missing Gemini selections should still use the default request model"
         )
 

--- a/Tests/GeminiServiceRequestTests.swift
+++ b/Tests/GeminiServiceRequestTests.swift
@@ -1,0 +1,46 @@
+import Foundation
+
+private func expect(_ condition: @autoclosure () -> Bool, _ message: String) {
+    guard condition() else {
+        fputs("FAIL: \(message)\n", stderr)
+        exit(1)
+    }
+}
+
+@main
+struct GeminiServiceRequestTests {
+    @MainActor
+    static func main() {
+        do {
+            let request = try GeminiService.makeRequest(
+                base64Image: "encoded-image",
+                apiKey: "test-api-key",
+                promptContent: "Return LaTeX",
+                model: "gemini-3.6-flash"
+            )
+
+            expect(request.url?.path.contains("/models/gemini-3.6-flash:generateContent") == true,
+                   "Requests should use the selected Gemini 3.6 Flash model")
+            expect(request.httpMethod == "POST", "Requests should use POST")
+
+            guard let body = request.httpBody,
+                  let payload = try JSONSerialization.jsonObject(with: body) as? [String: Any],
+                  let generationConfig = payload["generationConfig"] as? [String: Any] else {
+                fputs("FAIL: Request should contain a JSON generation config\n", stderr)
+                exit(1)
+            }
+
+            expect(generationConfig["temperature"] == nil,
+                   "Requests should omit the deprecated temperature parameter")
+            expect(generationConfig["candidateCount"] == nil,
+                   "Requests should omit the unsupported candidateCount parameter")
+            expect(generationConfig["maxOutputTokens"] as? Int == 2048,
+                   "Requests should retain the output token limit")
+
+            print("GeminiServiceRequestTests passed")
+        } catch {
+            fputs("FAIL: \(error)\n", stderr)
+            exit(1)
+        }
+    }
+}

--- a/scripts/run-standalone-tests.sh
+++ b/scripts/run-standalone-tests.sh
@@ -28,6 +28,12 @@ run_swift_test \
   ScreenScribe/Sources/Config.swift
 
 run_swift_test \
+  GeminiServiceRequestTests \
+  Tests/GeminiServiceRequestTests.swift \
+  ScreenScribe/Sources/Services/GeminiService.swift \
+  ScreenScribe/Sources/Config.swift
+
+run_swift_test \
   ScreenCaptureCLIArgumentsTests \
   Tests/ScreenCaptureCLIArgumentsTests.swift \
   ScreenScribe/Sources/Services/ScreenCaptureBackend.swift \


### PR DESCRIPTION
## Summary

- replace Gemini 3.5 Flash with Gemini 3.6 Flash as the default model
- replace Gemini 3.1 Flash-Lite with Gemini 3.5 Flash-Lite
- migrate saved legacy Flash and Flash-Lite selections to the new GA model IDs
- remove `temperature` and `candidateCount` from requests for compatibility with the latest Gemini models
- update the model documentation and add catalog/request regression coverage

## Why

Google released Gemini 3.6 Flash and Gemini 3.5 Flash-Lite as generally available models. Their migration guidance also deprecates sampling parameters such as `temperature` and does not support `candidateCount` for Gemini 3.x.

## User impact

Existing users keep their model preference category while being migrated to the corresponding current model. New installations default to Gemini 3.6 Flash.

## Validation

- `./scripts/run-standalone-tests.sh`
- unsigned Debug build with `xcodebuild`
- live headless API test with a controlled `E2E_OK` image:
  - Gemini 3.6 Flash returned `E2E_OK`
  - legacy Gemini 3.1 Flash-Lite selection migrated to Gemini 3.5 Flash-Lite and returned `E2E_OK`

Reference: https://ai.google.dev/gemini-api/docs/latest-model