### PR TITLE
chore: bump version to 2.1.2

### DIFF
--- a/Build.xcconfig
+++ b/Build.xcconfig
@@ -3,8 +3,8 @@
 
 PRODUCT_BUNDLE_IDENTIFIER = app.samuelz12.screenscribe-dev
 
-MARKETING_VERSION = 2.1.0
-CURRENT_PROJECT_VERSION = 13
+MARKETING_VERSION = 2.1.2
+CURRENT_PROJECT_VERSION = 14
 
 // Local.xcconfig is for developer-specific overrides.
 #include? "Local.xcconfig"

--- a/ScreenScribe/Info.plist
+++ b/ScreenScribe/Info.plist
@@ -14,6 +14,8 @@
   <key>CFBundleIdentifier</key>           <string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
   <key>CFBundleName</key>                 <string>$(PRODUCT_NAME)</string>
   <key>CFBundlePackageType</key>          <string>APPL</string>
+  <key>CFBundleShortVersionString</key>   <string>$(MARKETING_VERSION)</string>
+  <key>CFBundleVersion</key>              <string>$(CURRENT_PROJECT_VERSION)</string>
   <key>LSUIElement</key>                  <true/>          <!-- menu-bar-only app -->
   <key>NSPrincipalClass</key>             <string>NSApplication</string>
 


### PR DESCRIPTION
## Summary

- bump the app marketing version to 2.1.2
- increment the build number from 13 to 14
- add the standard version keys to the app Info.plist so release bundles expose their version metadata

## Why

The Gemini model update is ready for release as v2.1.2. The existing project defined version values in Build.xcconfig, but the source Info.plist did not consume them, leaving built app bundles without CFBundleShortVersionString or CFBundleVersion.

## Validation

- `./scripts/run-standalone-tests.sh`
- unsigned Release build with `xcodebuild`
- source Info.plist passes `plutil -lint`
- built app reports version `2.1.2` and build `14`